### PR TITLE
Add a GitHub Actions workflow to run automated tests without requiring openssl/mongoose builds

### DIFF
--- a/.github/workflows/automated-testing.yaml
+++ b/.github/workflows/automated-testing.yaml
@@ -1,0 +1,51 @@
+name: Automated Testing (Windows)
+
+on:
+  pull_request:
+    paths-ignore:
+      - "README.md"
+      - .github/**
+      - '!.github/workflows/automated-testing.yaml'
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
+      - .github/**
+      - '!.github/workflows/ci-windows.yaml'
+  create:
+    paths-ignore:
+      - "README.md"
+      - .github/**
+      - "!.github/workflows/automated-testing.yaml"
+
+jobs:
+  build:
+    name: Test on Windows (x64)
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Fetch latest evo version tag
+        # This seems like a hacky way of getting the tag, but I haven't found a better one that "just works"
+        run: curl --location --silent --head --output curl.log -w %{url_effective} https://github.com/evo-lua/evo/releases/latest | grep --only-matching tag/.* | cut -f2- -d/ | tee LATEST_VERSION_TAG && cat curl.log # Print everything, for easier debugging
+        shell: bash
+
+      - name: Download evo release
+        run: curl --location --silent --fail --output evo.exe https://github.com/evo-lua/evo/releases/download/$(cat LATEST_VERSION_TAG)/evo.exe &&  ls && ./evo.exe # Output version to allow troubleshooting issues more easily if it's wrong
+        shell: bash
+
+      - name: Fetch latest mongoose-ffi version tag
+        run: rm LATEST_VERSION_TAG && curl --location --silent --head --output curl.log -w %{url_effective} https://github.com/evo-lua/mongoose-ffi/releases/latest | grep --only-matching tag/.* | cut -f2- -d/ | tee LATEST_VERSION_TAG && cat curl.log
+        shell: bash
+
+      - name: Download mongoose.dll
+        run: curl --location --silent --fail --output mongoose.dll https://github.com/evo-lua/mongoose-ffi/releases/download/$(cat LATEST_VERSION_TAG)/mongoose.dll
+        shell: bash
+
+      - name: Run automated tests
+        run: test.cmd
+        shell: cmd


### PR DESCRIPTION
This avoids having to build the latest mongoose shared library, at the cost of not always being up to date. The tests are also run as part of the regular build workflow, so if there's ever a discrepancy it should be detected.